### PR TITLE
stack: Add `nix` section with required packages

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -85,3 +85,13 @@ extra-package-dbs: []
 #
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+
+nix:
+    packages:
+      - cairo
+      - gobject-introspection
+      - gtk3
+      - libxml2
+      - pango
+      - pkgconfig
+      - zlib


### PR DESCRIPTION
Hi.

In order to save other Nix users the hassle of figuring out the packages they have to install in order to build the project with the `stack` tool, this PR adds the required packages to the `nix` section.

`stack` will take care of providing the required dependencies in ghc's build environment on NixOS automatically.