### PR TITLE
Remove `body-images` from capabilities

### DIFF
--- a/src/NotificationCenter/Notifications.hs
+++ b/src/NotificationCenter/Notifications.hs
@@ -82,8 +82,7 @@ getCapabilities config = return ( [ "body"
                                   , "actions"
                                   , "persistence"
                                   , "icon-static"
-                                  , "action-icons"
-                                  , "body-images" ]
+                                  , "action-icons" ]
                                   ++ if (configNotiMarkup config) then
                                     [ "body-markup"
                                     , "body-hyperlinks"] else [])


### PR DESCRIPTION
Currently, embedding `<img .../>` tags is not supported.

Fixes #27.