### PR TITLE
Allow customization of Top and Right displacement per notification

### DIFF
--- a/README.org
+++ b/README.org
@@ -540,6 +540,8 @@ You can set the following parameters:
 - app
 - time
 - timeout (specified in milliseconds)
+- right (overrides ~distanceRight~ from the configuration)
+- top (overrides ~distanceTop~ from the configuration)
 - icon (does not do anything, currently)
 - transient (value has to be =true= or =false=)
 - noClosedMsg (value has to be =true= or =false=, if set to true it

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -10,7 +10,7 @@ import Data.List.Split (splitOn)
 import Helpers (split, removeOuterLetters, readConfig, replace)
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as Text
-import Data.Int ( Int32 )
+import Data.Int ( Int32, Int )
 import NotificationCenter.Notifications.Data
   (notiSendClosedMsg, notiTransient, notiIcon, notiTime, notiAppName
   , notiBody, notiSummary, Notification(..))
@@ -189,6 +189,8 @@ getConfig p =
                                 | k == "app" = noti { notiAppName = Text.pack v }
                                 | k == "time" = noti { notiTime = Text.pack v }
                                 | k == "timeout" = noti { notiTimeout = read v :: Int32 }
+                                | k == "right" = noti { notiRight = Just . (read :: String -> Int) $ v }
+                                | k == "top" = noti { notiTop = Just . (read :: String -> Int) $ v }
 --                                | k == "icon" = noti { notiIcon = Text.pack v }
                                 | k == "transient" && v == "true" = noti { notiTransient = True }
                                 | k == "transient" && v == "false" = noti { notiTransient = False }

--- a/src/NotificationCenter/Notifications.hs
+++ b/src/NotificationCenter/Notifications.hs
@@ -240,6 +240,8 @@ notify config tState emit
         , notiTime = time
         , notiTransient = parseTransient hints
         , notiSendClosedMsg = (configSendNotiClosedDbusMessage config)
+        , notiTop = Nothing
+        , notiRight = Nothing
         }
 
   if Map.member (pack "deadd-notification-center")

--- a/src/NotificationCenter/Notifications/Data.hs
+++ b/src/NotificationCenter/Notifications/Data.hs
@@ -10,7 +10,7 @@ module NotificationCenter.Notifications.Data
 
 import qualified Data.Text as Text
 import Data.Word ( Word32, Word8 )
-import Data.Int ( Int32 )
+import Data.Int ( Int32, Int )
 import qualified Data.ByteString as BS
 import Foreign.Marshal.Array (newArray)
 import Foreign.C.Types (CUChar(..))
@@ -44,6 +44,8 @@ data Notification = Notification
   , notiTransient :: Bool
   , notiSendClosedMsg :: Bool -- ^ If notiOnClosed should be ignored
   , notiOnClosed :: CloseType -> IO ()
+  , notiTop :: Maybe Int
+  , notiRight :: Maybe Int
     -- ^ Should be called when the notification is closed, either by
     --   timeout or by user
   , notiOnAction :: String -> IO ()
@@ -67,6 +69,8 @@ instance Show Notification where
     , "  notiTime = " ++ (show $ notiTime n) ++ ", \n" 
     , "  notiTransient = " ++ (show $ notiTransient n) ++ ", \n" 
     , "  notiSendClosedMsg = " ++ (show $ notiSendClosedMsg n) ++ "\n" 
+    , "  notiTop = " ++ (show $ notiTop n) ++ "\n"
+    , "  notiRight = " ++ (show $ notiRight n) ++ "\n"
     , " } " ]
 
 data Image = RawImg

--- a/src/NotificationCenter/Notifications/NotificationPopup.hs
+++ b/src/NotificationCenter/Notifications/NotificationPopup.hs
@@ -26,6 +26,7 @@ import Data.Word ( Word32 )
 import Data.Int ( Int32 )
 import qualified Data.Map as Map ( Map )
 import Data.List ( sortOn )
+import Data.Maybe ( fromMaybe )
 
 import Control.Monad
 import DBus ( Variant (..) )
@@ -59,8 +60,9 @@ showNotificationWindow :: Config -> Notification
   -> [DisplayingNotificationPopup] -> (IO ()) -> IO DisplayingNotificationPopup
 showNotificationWindow config noti dispNotis onClose = do
 
-  let distanceTop = configDistanceTop config
+  let distanceTop = fromMaybe (configDistanceTop config) (notiTop noti)
       distanceBetween = configDistanceBetween config
+      distanceRight = fromMaybe (configDistanceRight config) (notiRight noti)
 
   (objs, builder) <- createTransparentWindow (Text.pack glade)
     [ "main_window"
@@ -104,7 +106,7 @@ showNotificationWindow config noti dispNotis onClose = do
 
   windowMove mainWindow
     (screenW - fromIntegral
-     (configWidthNoti config + configDistanceRight config))
+     (configWidthNoti config + distanceRight))
     hBefore
 
   onWidgetButtonPressEvent mainWindow $ \eventButton -> do

--- a/src/NotificationCenter/Notifications/NotificationPopup.hs
+++ b/src/NotificationCenter/Notifications/NotificationPopup.hs
@@ -25,8 +25,8 @@ import Data.Text as Text
 import Data.Word ( Word32 )
 import Data.Int ( Int32 )
 import qualified Data.Map as Map ( Map )
-import Data.List ( sortOn )
-import Data.Maybe ( fromMaybe )
+import Data.List ( sortOn, filter )
+import Data.Maybe ( fromMaybe, isJust )
 
 import Control.Monad
 import DBus ( Variant (..) )
@@ -42,7 +42,6 @@ instance Eq DisplayingNotificationPopup where
   a == b = _dNotiId a == _dNotiId b
 
 
-
 data DisplayingNotificationPopup = DisplayingNotificationPopup
   { _dpopupContent :: DisplayingNotificationContent
   , _dNotiGetHeight :: IO Int32
@@ -51,18 +50,22 @@ data DisplayingNotificationPopup = DisplayingNotificationPopup
   , _dNotiDestroy :: IO ()
   , _dMainWindow :: Gtk.Window
   , _dLabelBG :: Gtk.Label
+  , _dHasCustomPosition :: Bool
   }
 makeClassy ''DisplayingNotificationPopup
 instance HasDisplayingNotificationContent DisplayingNotificationPopup where
   displayingNotificationContent = dpopupContent
 
+
 showNotificationWindow :: Config -> Notification
   -> [DisplayingNotificationPopup] -> (IO ()) -> IO DisplayingNotificationPopup
 showNotificationWindow config noti dispNotis onClose = do
 
-  let distanceTop = fromMaybe (configDistanceTop config) (notiTop noti)
+  let distanceTopFromConfig = configDistanceTop config
+      distanceTop = fromIntegral $ fromMaybe distanceTopFromConfig (notiTop noti)
       distanceBetween = configDistanceBetween config
       distanceRight = fromMaybe (configDistanceRight config) (notiRight noti)
+      hasCustomPosition = (isJust $ notiTop noti) || (isJust $ notiRight noti)
 
   (objs, builder) <- createTransparentWindow (Text.pack glade)
     [ "main_window"
@@ -78,6 +81,7 @@ showNotificationWindow config noti dispNotis onClose = do
     , _dLabelBG = labelBG
     , _dNotiId = notiId noti
     , _dNotiDestroy = widgetDestroy mainWindow
+    , _dHasCustomPosition = hasCustomPosition
     , _dpopupContent = DisplayingNotificationContent {} }
 
   let dispNoti = set dNotiGetHeight
@@ -100,9 +104,12 @@ showNotificationWindow config noti dispNotis onClose = do
                                    (fromIntegral $ configNotiMonitor config)
 
   hBefores <- sortOn fst <$> mapM
-    (\n -> (,) (_dNotiTop n) <$> (_dNotiGetHeight n)) dispNotis
-  let hBefore = findBefore hBefores ((fromIntegral distanceTop) + screenY)
-                height (fromIntegral distanceBetween)
+    (\n -> (,) (_dNotiTop n) <$> (_dNotiGetHeight n)) (Data.List.filter (not . _dHasCustomPosition) dispNotis)
+  let hBefore = if hasCustomPosition then
+                  distanceTop
+                else
+                  findBefore hBefores (distanceTop + screenY)
+                  height (fromIntegral distanceBetween)
 
   windowMove mainWindow
     (screenW - fromIntegral


### PR DESCRIPTION
closes #47 

Ideally, those options, `distanceRight` and `distanceTop` would be all customizable with a percentage as well instead of only a X/Y anchor; that is out of scope for this MR, though.