### PR TITLE
Parse gt lt entities

### DIFF
--- a/src/Helpers.hs
+++ b/src/Helpers.hs
@@ -155,6 +155,8 @@ parseHtmlEntities =
                      "grave" -> "`"
                      "amp" -> "&"
                      "tilde" -> "~"
+                     "lt" -> "<"
+                     "gt" -> ">"
                      "" -> matched
                      _ -> matched
         in a ++ repl ++ (if length c > 0 then parseNamedEntities c else "")


### PR DESCRIPTION
I have been getting `&gt;` and `&lt;` in my riot.im chats (now element), since I think its used for quoting. So, I should add those in as parsable html entities. 

Relevant: #72