### PR TITLE
Handle unbound mouse button clicks on a notification

### DIFF
--- a/src/NotificationCenter/Notifications/NotificationPopup.hs
+++ b/src/NotificationCenter/Notifications/NotificationPopup.hs
@@ -150,7 +150,7 @@ showNotificationWindow config noti dispNotis onClose = do
            putStrLn $ "Warning: Unknown mouse button '" ++ (show $ configPopupDefaultActionButton config) ++ "'."
            notiOnClosed noti $ User
            onClose
-       | not validInput -> do
+       | otherwise -> do
            putStrLn $ "Warning: Popup received unknown mouse input '" ++ (show mouseButton) ++ "'."
            notiOnClosed noti $ User
            onClose


### PR DESCRIPTION
Problem: button clicks which aren't bound in a configuration file to either
dismiss or perform an action on a notification crash the notification center

Solution: add a catch-all clause to mouse button handling routine, closing
the notification if an unknown button press is received.

Closes https://github.com/phuhl/linux_notification_center/issues/101