### PR TITLE
Update Gi-pango and Related Dependencies

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -41,25 +41,27 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps: [ ConfigFile-1.1.4
             , system-locale-0.3.0.0
+            , gi-harfbuzz-0.0.3
             , dbus-0.10.15
             , gtk3-0.15.4
             , stm-2.5.0.0
             , hgettext-0.1.31.0
-            , glib-0.13.8.0
-            , pango-0.13.8.0
+            , glib-0.13.8.1
+            , pango-0.13.8.1
             , gio-0.13.8.0
-            , gi-pango-1.0.22
-            , haskell-gi-0.23.0
-            , haskell-gi-base-0.23.0
-            , gi-glib-2.0.23
-            , gi-cairo-1.0.23
-            , gi-atk-2.0.21
-            , gi-gdk-3.0.22
-            , gi-gdkpixbuf-2.0.23
-            , gi-gio-2.0.26
-            , gi-gobject-2.0.22
-            , gi-gtk-3.0.32
-            , gi-graphene-1.0.1
+            , gi-pango-1.0.23
+            , haskell-gi-0.24.5
+            , haskell-gi-base-0.24.4
+            , gi-glib-2.0.24
+            , gi-cairo-1.0.24
+            , gi-atk-2.0.22
+            , gi-gdk-3.0.23
+            , gi-gdkpixbuf-2.0.24
+            , gi-gio-2.0.27
+            , gi-gobject-2.0.23
+            , gi-gtk-3.0.36
+            , gi-graphene-1.0.2
+            , ansi-terminal-0.11
             ]
 
 # Override default flag values for local packages and extra-deps

--- a/stack.yaml
+++ b/stack.yaml
@@ -58,7 +58,7 @@ extra-deps: [ ConfigFile-1.1.4
             , gi-gdk-3.0.23
             , gi-gdkpixbuf-2.0.24
             , gi-gio-2.0.27
-            , gi-gobject-2.0.23
+            , gi-gobject-2.0.25
             , gi-gtk-3.0.36
             , gi-graphene-1.0.2
             , ansi-terminal-0.11


### PR DESCRIPTION
Could not compile with gi-pango-1.0.22 as specified in the latest stack.yaml file.
This is due to a bug in that specific version where it could not parse harfbuzz.
Further information on the error as well as the merge to fix it in here:
https://github.com/haskell-gi/haskell-gi/issues/298

The fix has been implemented in gi-pango-1.0.23. That package also requires gi-harfbuzz-0.0.3 as a new dependency. 
The rest of the dependencies have been updated in accordance with this sheet:
https://hackage.haskell.org/package/gi-pango

I was able to build successfully using this configuration.

Definitely closes #85 , could potentially close #45 as well since it was a gtk3 error and gi-gtk is bumped to 3.0.36. There is a thread mentioning it was fixed in gtk3-3.24.7

https://bugs.archlinux.org/task/61486