### PR TITLE
Replace Depricated Control.Monad.Error with Control.Monad.Except

### DIFF
--- a/src/Helpers.hs
+++ b/src/Helpers.hs
@@ -1,7 +1,7 @@
 module Helpers where
 
 import qualified Data.ConfigFile as CF
-import qualified Control.Monad.Error as Error
+import qualified Control.Monad.Except as Error
 import Control.Applicative ((<|>))
 import Data.Maybe (fromMaybe)
 import Data.Functor (fmap)
@@ -31,7 +31,7 @@ translate = unsafePerformIO . getText
 
 readConfig :: CF.Get_C a => a -> CF.ConfigParser -> String -> String -> a
 readConfig defaultVal conf sec opt = fromEither defaultVal
-  $ fromEither (Right defaultVal) $ Error.runErrorT $ CF.get conf sec opt
+  $ fromEither (Right defaultVal) $ Error.runExceptT $ CF.get conf sec opt
 
 readConfigFile :: String -> IO CF.ConfigParser
 readConfigFile path = do


### PR DESCRIPTION
Closes #107 
The change was more trivial than i thought. If i viewed all the hs filed correctly, this is the only file that imports this specific function.

Deprecation listed here:
http://hackage.haskell.org/package/mtl-2.2.2/docs/Control-Monad-Error.html