### PR TITLE
Support 1.x versions of the D-Bus client library and switch to env-locale

### DIFF
--- a/linux-notification-center.cabal
+++ b/linux-notification-center.cabal
@@ -54,7 +54,7 @@ library
                      , bytestring
                      , ConfigFile
                      , mtl
-                     , dbus >= 0.10.15 && < 2
+                     , dbus >= 1.0.1 && < 2
                      , containers
                      , unix
                      , stm >= 2.5.0.0

--- a/linux-notification-center.cabal
+++ b/linux-notification-center.cabal
@@ -48,7 +48,7 @@ library
                      , gi-gtk >= 3.0.19
                      , gi-gio
                      , time
-                     , system-locale
+                     , env-locale
                      , gi-gobject
                      , text
                      , bytestring

--- a/linux-notification-center.cabal
+++ b/linux-notification-center.cabal
@@ -54,7 +54,7 @@ library
                      , bytestring
                      , ConfigFile
                      , mtl
-                     , dbus >= 0.10.15 && < 1
+                     , dbus >= 0.10.15 && < 2
                      , containers
                      , unix
                      , stm >= 2.5.0.0

--- a/src/NotificationCenter.hs
+++ b/src/NotificationCenter.hs
@@ -43,7 +43,7 @@ import Control.Concurrent.STM
   ( readTVarIO, modifyTVar', TVar(..), atomically, newTVarIO )
 
 import System.Process (runCommand)
-import System.Locale.Read
+import System.Locale.Current
 import System.Posix.Signals (sigUSR1)
 import System.Posix.Daemonize (serviced, daemonize)
 import System.Directory (getXdgDirectory, XdgDirectory(..))
@@ -103,7 +103,7 @@ setTime :: TVar State -> IO Bool
 setTime tState = do
   state <- readTVarIO tState
   now <- zonedTimeToLocalTime <$> getZonedTime
-  zone <- System.Locale.Read.getCurrentLocale
+  zone <- System.Locale.Current.currentLocale
   let format = Text.pack . flip (formatTime zone) now
   labelSetText (stTimeLabel state) $ format "%H:%M"
   labelSetText (stDateLabel state) $ format "%A, %x"

--- a/src/NotificationCenter/Notifications.hs
+++ b/src/NotificationCenter/Notifications.hs
@@ -408,11 +408,9 @@ notificationDaemon config onNote onCloseNote = do
       "Notify" (onNote (emit client))
     ]
 #endif
-
 startNotificationDaemon :: Config -> IO () ->  IO () ->  IO (TVar NotifyState)
 startNotificationDaemon config onUpdate onUpdateForMe = do
   istate <- newTVarIO $ NotifyState [] [] 1 onUpdate onUpdateForMe config []
   forkIO (notificationDaemon config (notify config istate)
           (closeNotification istate))
   return istate
-

--- a/src/NotificationCenter/Notifications.hs
+++ b/src/NotificationCenter/Notifications.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 
 module NotificationCenter.Notifications
   ( startNotificationDaemon
@@ -31,6 +32,9 @@ import DBus (Variant(..), Structure(..), fromVariant, signal, toVariant, variant
 import DBus.Internal.Message (Signal(..))
 import DBus.Client
        ( connectSession, AutoMethod(..), autoMethod, requestName, export
+#if MIN_VERSION_dbus(1,0,0)
+       , defaultInterface, interfaceName, interfaceMethods
+#endif
        , nameAllowReplacement, nameReplaceExisting, emit)
 import Data.Char (toLower)
 import Data.Text (unpack, Text, pack )
@@ -382,6 +386,17 @@ notificationDaemon config onNote onCloseNote = do
   client <- connectSession
   _ <- requestName client "org.freedesktop.Notifications"
        [nameAllowReplacement, nameReplaceExisting]
+#if MIN_VERSION_dbus(1,0,0)
+  export client "/org/freedesktop/Notifications" defaultInterface
+    { interfaceName = "org.freedesktop.Notifications"
+    , interfaceMethods =
+      [ autoMethod "GetServerInformation" getServerInformation
+      , autoMethod "GetCapabilities" (getCapabilities config)
+      , autoMethod "CloseNotification" onCloseNote
+      , autoMethod "Notify" (onNote (emit client))
+      ]
+    }
+#else
   export client "/org/freedesktop/Notifications"
     [ autoMethod "org.freedesktop.Notifications"
       "GetServerInformation" getServerInformation
@@ -392,6 +407,7 @@ notificationDaemon config onNote onCloseNote = do
     , autoMethod "org.freedesktop.Notifications"
       "Notify" (onNote (emit client))
     ]
+#endif
 
 startNotificationDaemon :: Config -> IO () ->  IO () ->  IO (TVar NotifyState)
 startNotificationDaemon config onUpdate onUpdateForMe = do

--- a/src/NotificationCenter/Notifications.hs
+++ b/src/NotificationCenter/Notifications.hs
@@ -47,7 +47,7 @@ import Data.Time
 import Data.Time.LocalTime
 import Data.Maybe (fromMaybe)
 
-import System.Locale.Read
+import System.Locale.Current
 import System.IO (readFile)
 import System.IO.Error (tryIOError)
 import Data.GI.Base.GError (catchGErrorJust)
@@ -194,7 +194,7 @@ parseImg hints text =
 
 getTime = do
   now <- zonedTimeToLocalTime <$> getZonedTime
-  zone <- System.Locale.Read.getCurrentLocale
+  zone <- System.Locale.Current.currentLocale
   let format = pack . flip (formatTime zone) now
   return $ format "%H:%M"
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,6 +43,7 @@ extra-deps: [ ConfigFile-1.1.4
             , system-locale-0.3.0.0
             , gi-harfbuzz-0.0.3
             , dbus-0.10.15
+            , env-locale-1.0.0.1
             , gtk3-0.15.4
             , stm-2.5.0.0
             , hgettext-0.1.31.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,7 +41,6 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps: [ ConfigFile-1.1.4
             , gi-harfbuzz-0.0.3
-            , dbus-0.10.15
             , env-locale-1.0.0.1
             , gtk3-0.15.4
             , stm-2.5.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,7 +40,6 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps: [ ConfigFile-1.1.4
-            , system-locale-0.3.0.0
             , gi-harfbuzz-0.0.3
             , dbus-0.10.15
             , env-locale-1.0.0.1

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,13 +12,6 @@ packages:
   original:
     hackage: ConfigFile-1.1.4
 - completed:
-    hackage: system-locale-0.3.0.0@sha256:13b3982403d8ac8cc6138e68802be8d8e7cf7ebc4cbc7e47e99e3c0dd1be066a,1529
-    pantry-tree:
-      size: 446
-      sha256: 3b22af3e6315835bf614a0d30381ec7e47aca147b59ba601aeaa26f1fdc19373
-  original:
-    hackage: system-locale-0.3.0.0
-- completed:
     hackage: gi-harfbuzz-0.0.3@sha256:0550f498854b7edac66b1a09f283e5b5c86033aff58b4ac30b024ae59e1bd866,5869
     pantry-tree:
       size: 364
@@ -26,12 +19,12 @@ packages:
   original:
     hackage: gi-harfbuzz-0.0.3
 - completed:
-    hackage: dbus-0.10.15@sha256:0cbccdf3f249f7d1485643df6e1a70d360b02b467fdc37c61c73de7fb327336d,4079
+    hackage: env-locale-1.0.0.1@sha256:aedab9b7bbed9f523f9821771b4c67d64f34a00be2be60de1d25b1a97278d475,894
     pantry-tree:
-      size: 2275
-      sha256: 8ac4beea6d6a51079e7f47506822803da8ac26fff7a0aff905debcf350a643e8
+      size: 271
+      sha256: 091cde93ceb962d18f21ec926436dc03bab61137db9eae9841f6c75725e09e5f
   original:
-    hackage: dbus-0.10.15
+    hackage: env-locale-1.0.0.1
 - completed:
     hackage: gtk3-0.15.4@sha256:e8de08763cb757c4be202a4eb7551a108b49cd59aa90bc7e2d680893d5fccec1,19491
     pantry-tree:


### PR DESCRIPTION
I am unsure why the upper bound was set to `<1` for `dbus`. The changes to support 1.x were rather trivial and nothing has seemingly broken from what I can tell. I left support for the older versions of the library in case it is important. I am fine with removing older support if that is wanted.

The switch to env-locale from system-locale is my main motivation. As mentioned in the commit, system-locale requires the command `locale` visible in PATH. This is not always the case. See issue #63 for an example.