### PR TITLE
Notifications.hs: respect the XDG specification

### DIFF
--- a/linux-notification-center.cabal
+++ b/linux-notification-center.cabal
@@ -38,6 +38,7 @@ library
                      , gtk3 >= 0.15.4
                      , transformers
                      , cairo
+                     , filepath
                      , haskell-gi
                      , haskell-gi-base
                      , gi-cairo


### PR DESCRIPTION
getDesktopFile now looks in the following places:
  - $XDG_DATA_HOME/applications
   \ $HOME/.local/share/applications (if XDG_DATA_HOME is unset)
  - /usr/local/share/applications
  - /usr/share/applications
  - $XDG_DATA_DIRS/applications (enumerates through if multiple)

The first match is desktop file which shall be used according to spec.
This commit also correct the issue of readFile not expanding the tilde.

Resolves #122.