### PR TITLE
src/Helpers.hs: search locales in Makefile paths

### DIFF
--- a/src/Helpers.hs
+++ b/src/Helpers.hs
@@ -47,7 +47,7 @@ getMoFile = do
         , "translation" </> takeWhile (/= '.') currentLocale
         , "translation" </> takeWhile (/= '_') currentLocale
         ]
-  filterM doesFileExist pathsFromCabal >>= return . head
+  filterM doesFileExist (pathsFromCabal ++ paths) >>= return . head
 
 getCatalog = getMoFile >>= loadCatalog
 


### PR DESCRIPTION
Forgot to concatenate the Makefile paths to the paths from cabal.
Should fix #184, @xircon can you try to see if this fixes your problem?