### PR TITLE
remove deprecated runCommand and banish zombies

### DIFF
--- a/src/NotificationCenter/Button.hs
+++ b/src/NotificationCenter/Button.hs
@@ -9,6 +9,8 @@ module NotificationCenter.Button
 import Config (Config(..))
 import TransparentWindow
 
+import Control.Exception (finally)
+
 import GI.Gtk
        (widgetSetHalign, widgetSetHexpand, buttonNew, setWidgetMargin
        , buttonSetRelief, widgetSetSizeRequest, widgetShowAll, widgetShow
@@ -36,7 +38,7 @@ import GI.Gtk.Enums
 
 import qualified GI.Gtk as Gtk (containerAdd, Box(..), Label(..), Button(..))
 import qualified Data.Text as Text
-import System.Process (runCommand)
+import System.Process (spawnCommand, interruptProcessGroupOf, waitForProcess)
 
 data Button = Button
   { buttonButton :: Gtk.Button
@@ -69,7 +71,8 @@ createButton config width height command description = do
     addSource $ do
       setButtonState2 $ theButton
       return False
-    runCommand command
+    ph <- spawnCommand command
+    waitForProcess ph `finally` interruptProcessGroupOf ph
     return ()
   Gtk.containerAdd button label
   return theButton

--- a/src/NotificationCenter/Notifications/Action.hs
+++ b/src/NotificationCenter/Notifications/Action.hs
@@ -36,7 +36,6 @@ import GI.Gtk.Enums
 
 import qualified GI.Gtk as Gtk (containerAdd, Box(..), Label(..), Button(..))
 import qualified Data.Text as Text
-import System.Process (runCommand)
 
 data Action = Action
   { actionButton :: Gtk.Button


### PR DESCRIPTION
Use `interruptProcessGroupOf` to ensure the shell is killed.
Alternatively, if not using `shell` (which is used internally by
spawnCommand) terminateProcess would work.

This fixes #126, @ahmubashshir if you want to give this a test.