### PR TITLE
fix: gi-pango version for compilation to work

### DIFF
--- a/deadd-notification-center.cabal
+++ b/deadd-notification-center.cabal
@@ -47,7 +47,7 @@ library
                      , haskell-gi-base
                      , haskell-gettext
                      , gi-cairo
-                     , gi-pango
+                     , gi-pango >= 1.0.26
                      , gi-glib >= 2.0.17
                      , gi-gdk
                      , gi-gdkpixbuf >= 2.0.26

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,6 +43,7 @@ extra-deps:
   [
     env-locale-1.0.0.1,
     haskell-gettext-0.1.2.0,
+    gi-pango-1.0.27@sha256:3e9c5497382e8f112e834269de624980578cb6401e46f6537e694f94094b3af2,
   ]
 
 # Override default flag values for local packages and extra-deps


### PR DESCRIPTION
I know pretty much nothing about Haskall other than its package management being really annoying, so I don't expect this to get merged. But this is what I needed to change to get this to compile on Fedora 36. Might help others.