### PR TITLE
stack: bump stack resolver to lts 21.3

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-19.4
+resolver: lts-21.3
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -40,13 +40,8 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:
-  [
-    env-locale-1.0.0.1,
-    haskell-gettext-0.1.2.0,
-    gi-pango-1.0.27@sha256:3e9c5497382e8f112e834269de624980578cb6401e46f6537e694f94094b3af2,
-    gi-harfbuzz-0.0.6,
-    gi-freetype2-2.0.2,
-  ]
+  - env-locale-1.0.0.1
+  - haskell-gettext-0.1.2.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -18,30 +18,9 @@ packages:
       size: 579
   original:
     hackage: haskell-gettext-0.1.2.0
-- completed:
-    hackage: gi-pango-1.0.27@sha256:3e9c5497382e8f112e834269de624980578cb6401e46f6537e694f94094b3af2,7461
-    pantry-tree:
-      sha256: a9fbc13fa28da5d18e2ab39e9f8045b92e89d2ff65bdb7046955e965b1f398be
-      size: 361
-  original:
-    hackage: gi-pango-1.0.27@sha256:3e9c5497382e8f112e834269de624980578cb6401e46f6537e694f94094b3af2
-- completed:
-    hackage: gi-harfbuzz-0.0.6@sha256:c3f90157c220ba9aa8d1e221e5d7d73c528dac62fa4866058432c7dc14f76c90,6512
-    pantry-tree:
-      sha256: 1c26234a2de28fac847086802bdaa3a973b9f852141c2fc52ae9bc4ae0df5ac3
-      size: 364
-  original:
-    hackage: gi-harfbuzz-0.0.6
-- completed:
-    hackage: gi-freetype2-2.0.2@sha256:3ceda91744fbec02b0f5972822e43f633807929ca0c719bbc1fb3d7598c96f0b,2754
-    pantry-tree:
-      sha256: c340d45b834b8494964c214c4b0958d768d374056e7a813eca09f512eebc42e9
-      size: 306
-  original:
-    hackage: gi-freetype2-2.0.2
 snapshots:
 - completed:
-    sha256: d4ee004c46ba878d2f304f5d748d493057be579192a8d148527f3ba55c9df57f
-    size: 618683
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/4.yaml
-  original: lts-19.4
+    sha256: 97710f56bf093fca0ee5d8dbe19d96b654c752e405b66795b4baedd84a794c60
+    size: 640010
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/3.yaml
+  original: lts-21.3


### PR DESCRIPTION
Bummp the Stack LTS resolver to 21.3, and remove extra-deps that are now part of the LTS snapshot.

This fixed the build for me, but considering it's been broken before, I wonder what might be missing for it to be completely reproducible. In another PR I hope to pin more package versions.