### PR TITLE
ci: use latest stack, resolver ghc, and cache deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions/cache@v3
+        name: Cache ~/.stack
+        with:
+          path: ~/.stack
+          key: stack-global-${{ hashFiles('stack.yaml') }}
+          restore-keys: stack-global-
+
       - uses: haskell/actions/setup@v2
         name: Setup Haskell Stack
         with:
@@ -20,12 +27,6 @@ jobs:
           stack-no-global: true
           stack-setup-ghc: true
           enable-stack: true
-
-      - uses: actions/cache@v2.1.3
-        name: Cache ~/.stack
-        with:
-          path: ~/.stack
-          key: ${{ runner.os }}-stack
 
       - name: Install non-hs dependencies
         run: sudo apt-get update && sudo apt-get install libgtk-3-dev gobject-introspection libgirepository1.0-dev libwebkit2gtk-4.0-dev libgtksourceview-3.0-dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
           restore-keys: stack-global-
 
       - uses: actions/cache@v3
-        name: Cachek .stack-work
+        name: Cache .stack-work
         with:
           path: .stack-work
           key: stack-work-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,9 @@
 name: CI
 
-# Trigger the workflow on push or pull request, but only for the main branch
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-        if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
+      - uses: actions/checkout@v3
 
       - uses: haskell/actions/setup@v2
         name: Setup Haskell Stack

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,39 +7,37 @@ on:
     branches: [main]
 
 jobs:
-  stack:
-    name: stack / ghc ${{ matrix.ghc }}
+  build:
+    name: Build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        stack: ["2.7.3"]
-        ghc: ["8.10.7"]
 
     steps:
       - uses: actions/checkout@v2
         if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
 
-      - uses: haskell/actions/setup@v1
+      - uses: haskell/actions/setup@v2
         name: Setup Haskell Stack
         with:
-          ghc-version: ${{ matrix.ghc }}
-          stack-version: ${{ matrix.stack }}
+          stack-version: latest
+          stack-no-global: true
+          stack-setup-ghc: true
           enable-stack: true
+
       - uses: actions/cache@v2.1.3
         name: Cache ~/.stack
         with:
           path: ~/.stack
-          key: ${{ runner.os }}-${{ matrix.ghc }}-stack
+          key: ${{ runner.os }}-stack
 
       - name: Install non-hs dependencies
         run: sudo apt-get update && sudo apt-get install libgtk-3-dev gobject-introspection libgirepository1.0-dev libwebkit2gtk-4.0-dev libgtksourceview-3.0-dev
 
       - name: Install dependencies
         run: |
-          stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks --only-dependencies
+          stack build --test --bench --no-run-tests --no-run-benchmarks --only-dependencies
       - name: Build
         run: |
-          stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks
+          stack build --test --bench --no-run-tests --no-run-benchmarks
       - name: Test
         run: |
-          stack test --system-ghc
+          stack test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,13 @@ jobs:
           key: stack-global-${{ hashFiles('stack.yaml') }}
           restore-keys: stack-global-
 
+      - uses: actions/cache@v3
+        name: Cachek .stack-work
+        with:
+          path: .stack-work
+          key: stack-work-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}
+          restore-keys: stack-work-
+
       - uses: haskell/actions/setup@v2
         name: Setup Haskell Stack
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,11 +39,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libgtk-3-dev gobject-introspection libgirepository1.0-dev libwebkit2gtk-4.0-dev libgtksourceview-3.0-dev
 
       - name: Install dependencies
-        run: |
-          stack build --test --bench --no-run-tests --no-run-benchmarks --only-dependencies
+        run: stack build --only-dependencies
+
       - name: Build
-        run: |
-          stack build --test --bench --no-run-tests --no-run-benchmarks
+        run: stack build
+
       - name: Test
-        run: |
-          stack test
+        run: stack test


### PR DESCRIPTION
This PR makes the following improvements to the CI workflow:

- The latest stable version of Stack is used instead of a fixed version. This
  shouldn't be a problem, as the Stack configuration dictates what version of
  GHC and which packages are downloaded.

- No version of GHC is fixed through the CI workflow, and instead we rely on
  what is written on `stack.yaml`, as originally intended, thus using whatever
  version our chosen resolver points to.

- The checkout action is always executed when the workflow runs, as it is
  imperative for the rest of the workflow to work.

- The global Stack directory is cached before Stack and GHC are setup, ensuring
  we don't waste Actions minutes downloading the same GHC installation over and
  over.

- The Stack work directory, containing built dependencies and built Haskell
  artifacts is cached, so only modules that have been modified need to be
  rebuilt.

- The previous workflow wasn't triggered by pushes to `master`, so that was
  amended.
