### PR TITLE
feat: hide body in popup if empty

### DIFF
--- a/README.org
+++ b/README.org
@@ -587,7 +587,12 @@ notification:
     ### Defines after how many lines of text the body will be truncated. 
     ### Use 0 if you want to disable truncation.
     max-lines-in-body: 3
-    
+
+    ### Determines whether the GTK widget that displays the notification body
+    ### in the notification popup will be hidden when empty. This is especially
+    ### useful for transient notifications that display a progress bar.
+    # hide-body-if-empty: false
+
     ### Monitor on which the notifications will be
     ### printed. If "follow-mouse" is set true, this does nothing.
     # monitor: 0

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -126,6 +126,7 @@ data Config = Config
   , configPopupEllipsizeBody :: Bool
   , configPopupDismissButton :: String
   , configPopupDefaultActionButton :: String
+  , configPopupHideBodyIfEmpty :: Bool
 
   -- buttons
   , configButtonsPerRow :: Int
@@ -242,6 +243,8 @@ instance FromJSON Config where
     <*> fourthLevel o "notification" "popup" "click-behavior" "dismiss" "mouse1"
   -- configPopupDefaultActionButton
     <*> fourthLevel o "notification" "popup" "click-behavior" "default-action" "mouse3"
+  -- configPopupHideBodyIfEmpty
+    <*> thirdLevel o "notification" "popup" "hide-body-if-empty" False
   -- configButtonsPerRow
     <*> thirdLevel o "notification-center" "buttons" "buttons-per-row" 5
   -- configButtonHeight

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -89,9 +89,9 @@ instance FromJSON ModificationRule where
 
 
 data Config = Config
- {
-   -- notification-center
-   configBarHeight :: Int
+  {
+  -- notification-center
+    configBarHeight :: Int
   , configBottomBarHeight :: Int
   , configRightMargin :: Int
   , configWidth :: Int
@@ -132,7 +132,7 @@ data Config = Config
   , configButtonHeight :: Int
   , configButtonMargin :: Int
   , configButtons :: [ButtonConfig]
-}
+  }
 
 (.:.) :: FromJSON a => Y.Parser (Maybe Y.Object) -> Text.Text -> Y.Parser (Maybe  a)
 (.:.) po name = do

--- a/src/NotificationCenter/Notifications/AbstractNotification.hs
+++ b/src/NotificationCenter/Notifications/AbstractNotification.hs
@@ -127,10 +127,14 @@ updateNotiContent :: HasDisplayingNotificationContent dn
   => Config -> Notification -> dn -> IO ()
 updateNotiContent config noti dNoti = do
   labelSetText (view dLabelTitel dNoti) $ notiSummary noti
-  if (configNotiMarkup config) then do
-      labelSetMarkup (view dLabelBody dNoti) $ markupify $ notiBody noti
-      else do
-      labelSetText (view dLabelBody dNoti) $ notiBody noti
+
+  if configNotiMarkup config
+    then labelSetMarkup (view dLabelBody dNoti) . markupify $ notiBody noti
+    else labelSetText (view dLabelBody dNoti) $ notiBody noti
+
+  when (configPopupHideBodyIfEmpty config && notiBody noti == "") $ do
+    widgetSetVisible (view dLabelBody dNoti) False
+
   if notiAppName noti /= "" then
     labelSetText (view dLabelAppname dNoti) $ notiAppName noti
     else


### PR DESCRIPTION
This pull request adds a configuration option that allows the notification body in popup windows to be hidden (set to invisible) if it is empty.

This is especially useful for transient notifications that do not need a body, but display a progress bar or buttons (e.g. volume control).
