### PR TITLE
stack: bump stack resolver: 21.3 -> 22.28

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-21.3
+resolver: lts-22.28
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -42,6 +42,12 @@ packages:
 extra-deps:
   - env-locale-1.0.0.1
   - haskell-gettext-0.1.2.0
+  # ConfigFile-1.2.0
+  #
+  # https://github.com/jgoerzen/configfile holds version 1.1.4 that has not been
+  # updated in 10 years and does not build with GHC after 9.4.
+  - git: https://github.com/rvl/configfile
+    commit: '83ee30b43f74d2b6781269072cf5ed0f0e00012f'
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -18,9 +18,20 @@ packages:
       size: 579
   original:
     hackage: haskell-gettext-0.1.2.0
+- completed:
+    commit: 83ee30b43f74d2b6781269072cf5ed0f0e00012f
+    git: https://github.com/rvl/configfile
+    name: ConfigFile
+    pantry-tree:
+      sha256: aed82f71ef30a2132aca35d12dc77fdfbae67616b94dd8ce93f822be256545bb
+      size: 1525
+    version: 1.2.0
+  original:
+    commit: 83ee30b43f74d2b6781269072cf5ed0f0e00012f
+    git: https://github.com/rvl/configfile
 snapshots:
 - completed:
-    sha256: 97710f56bf093fca0ee5d8dbe19d96b654c752e405b66795b4baedd84a794c60
-    size: 640010
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/3.yaml
-  original: lts-21.3
+    sha256: 87da71cb0ae9ee1ea1bf51a8eb9812f39f779be76abc0a3c926defd8afda05d1
+    size: 719139
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/28.yaml
+  original: lts-22.28


### PR DESCRIPTION
ConfigFile is absent from Stackage since 21.25, and it does not build with GHC 9.6.

At the same time haskell-gi has an important fix in 0.26.8:

https://github.com/haskell-gi/haskell-gi/pull/427

and Stackage 21.25 only has haskell-gi 0.26.7:

https://www.stackage.org/lts-21.25/package/haskell-gi-0.26.7